### PR TITLE
Remove (incorrect) unused `?Sized` bound

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ const DEFAULT_SHARD_COUNT: usize = 128;
 #[inline]
 fn equivalent_key<K, V>(k: &K) -> impl Fn(&(K, V)) -> bool + '_
 where
-    K: ?Sized + Eq,
+    K: Eq,
 {
     move |x| k.eq(x.0.borrow())
 }


### PR DESCRIPTION
This crate may break in https://github.com/rust-lang/rust/pull/123531.

The `K: ?Sized` bound is unused by any of the code in the library, and also isn't even theoretically *able* to be used either (Rust only allows the last field of a tuple to be unsized).

The Rust compiler wasn't checking the validity of closure arguments before rust-lang/rust#123531 -- therefore it didn't see that the argument `&(K, V)` was invalid in the closure being returned by `equivalent_key`, since Rust requires `K` to be `Sized` in order to be in the non-final position of a tuple.